### PR TITLE
Bypass ban by nominatim.openstreetmap.org on iOS

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -16,12 +16,17 @@ var GenericWeather = function() {
     Unknown         : 1000,
   };
 
-  this._xhrWrapper = function(url, type, callback) {
+  this._xhrWrapper = function(url, type, callback, customHeaderKey, customHeaderValue) {
     var xhr = new XMLHttpRequest();
     xhr.onload = function () {
       callback(xhr);
     };
     xhr.open(type, url);
+    
+    if (customHeaderKey && customHeaderValue) {
+      try {xhr.setRequestHeader(customHeaderKey, customHeaderValue);} catch(e){}
+    }
+    
     xhr.send();
   };
 
@@ -176,7 +181,7 @@ var GenericWeather = function() {
           } else {
             // console.log('weather: Error fetching data (HTTP Status: ' + req.status + ')');
           }
-        }.bind(this));
+        }.bind(this), 'User-Agent', 'Pebble Generic Weather');
 
       } else {
         console.log('weather: Error fetching data (HTTP Status: ' + req.status + ')');


### PR DESCRIPTION
When Forecast.io is used as Weather provider - nominatim.openstreetmap.org is used to get location name. The service is banned Pebble iOS app due to some past abuse and the call failed causing weather call to fail as well. This change adds custom user-agent header that bypasses the ban
