### PR TITLE
Improved finding of city name

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -175,7 +175,7 @@ var GenericWeather = function() {
         this._xhrWrapper(url, 'GET', function(req) {
           if(req.status == 200) {
             var json = JSON.parse(req.response);
-            var city = json.address.village || json.address.town || json.address.city || json.address.county || '';
+            var city = json.address.hamlet || json.address.village || json.address.town || json.address.city || json.address.county || '';
             message['GW_NAME'] = city;
             Pebble.sendAppMessage(message);
           } else {


### PR DESCRIPTION
City name in `nominatim.openstreetmap.org` service was located by checking village, town, city and county property. In some cases village, town, city properties was empty, resulting in county being displayed. By adding "hamlet" property precision is improved.
