### PR TITLE
s/Forecast.io/Dark Sky/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Read `include/pebble-generic-weather.h` for function and `enum` documentation.
 
 * [WeatherUnderGround](https://www.wunderground.com)
 
-* [Forecast.io](http://forecast.io)
+* [Dark Sky](https://darksky.net) (formally known as Forecast.io)
 
 ## Data returned
 

--- a/include/pebble-generic-weather.h
+++ b/include/pebble-generic-weather.h
@@ -64,8 +64,8 @@ typedef enum {
   GenericWeatherProviderOpenWeatherMap      = 0,
   //! WeatherUnderground
   GenericWeatherProviderWeatherUnderground  = 1,
-  //! Forecast.io
-  GenericWeatherProviderForecastIo          = 2,
+  //! Dark Sky (formally Forecast.io)
+  GenericWeatherProviderDarkSky             = 2,
 
   GenericWeatherProviderUnknown             = 1000,
 } GenericWeatherProvider;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -140,11 +140,11 @@ var GenericWeather = function() {
     }.bind(this));
   };
 
-  this._getWeatherF_IO = function(coords) {
-    var url = 'https://api.forecast.io/forecast/' + this._apiKey + '/'
+  this._getWeatherDS = function(coords) {
+    var url = 'https://api.darksky.net/forecast/' + this._apiKey + '/'
       + coords.latitude + ',' + coords.longitude + '?exclude=minutely,hourly,alerts,flags&units=si';
 
-    console.log('weather: Contacting forecast.io...');
+    console.log('weather: Contacting Dark Sky..');
     // console.log(url);
 
     this._xhrWrapper(url, 'GET', function(req) {
@@ -215,7 +215,7 @@ var GenericWeather = function() {
     switch(this._provider){
       case GenericWeather.ProviderOpenWeatherMap :      this._getWeatherOWM(coords);  break;
       case GenericWeather.ProviderWeatherUnderground :  this._getWeatherWU(coords);   break;
-      case GenericWeather.ProviderForecastIo :          this._getWeatherF_IO(coords); break;
+      case GenericWeather.ProviderDarkSky :             this._getWeatherDS(coords); break;
       default: break;
     }
   };
@@ -288,6 +288,6 @@ var GenericWeather = function() {
 
 GenericWeather.ProviderOpenWeatherMap       = 0;
 GenericWeather.ProviderWeatherUnderground   = 1;
-GenericWeather.ProviderForecastIo           = 2;
+GenericWeather.ProviderDarkSky              = 2;
 
 module.exports = GenericWeather;


### PR DESCRIPTION
Forecast.io is being replaced by Dark Sky. This is mostly a branding
issue, but the API endpoint is changing.

None of this is all that pressing. The old API endpoint will continue to work, but no time like the present. :-)
