### PR TITLE
Some browsers need the Yahoo url to be URI encoded

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -218,7 +218,7 @@ var GenericWeather = function() {
     console.log('weather: Contacting Yahoo! Weather...');
     // console.log(url);
 
-    this._xhrWrapper(url, 'GET', function(req) {
+    this._xhrWrapper(encodeURI(url), 'GET', function(req) {
       console.log('weather: Got API response!');
       if(req.status == 200) {
         var json = JSON.parse(req.response);


### PR DESCRIPTION
Noticed while testing that the XHR request fails in Chrome because the Yahoo url has characters that need to be URI encoded. Haven't noticed any issues on iOS, not sure about Android.